### PR TITLE
Add find and contains to str.zh & Fix SIGFPE (Arithmetic exception)

### DIFF
--- a/src/lang/lang_tables.cpp
+++ b/src/lang/lang_tables.cpp
@@ -31,22 +31,6 @@ const TYPE FT = new TypeInfo{.name = "F", .complete = true, .defined = DEFINED::
 }
 namespace tables {
 
-const std::unordered_map<std::string, bool> flags{
-    {"tokens", false},
-    {"exp_parser_logs", false},
-    {"show_ast", false},
-    {"show_st", false},
-    {"show_c", false},
-    {"show_original", false},
-    {"B", false},
-    {"stack_trace", false},
-    {"show_bytecode", false},
-    {"pure", false},
-};
-const std::unordered_map<Str, Str> options{
-    {"compiler", "gcc"},
-};
-
 const std::vector<std::pair<TOKEN, std::string>> lexer_tokens{
     {TOKEN::str_literal, R"(('(\\.|[^'\\])*'|`(?:\\`|[^`])*`))"},
     {TOKEN::id,

--- a/src/lang/lang_tables.hpp
+++ b/src/lang/lang_tables.hpp
@@ -11,8 +11,6 @@
 
 namespace tables {
 
-extern const std::unordered_map<std::string, bool> flags;
-extern const std::unordered_map<Str, Str> options;
 extern const std::vector<std::pair<TOKEN, std::string>> lexer_tokens;
 extern const std::unordered_set<std::string> banned_ids;
 extern const std::unordered_set<std::string> flow_ops;

--- a/src/lang/zhdata.hpp
+++ b/src/lang/zhdata.hpp
@@ -26,8 +26,9 @@ struct ZHDATA {
   Path bin_path;
   Path std_path;
 
-  std::unordered_map<std::string, bool> flags = tables::flags;
-  std::unordered_map<Str, Str> options = tables::options;
+  /** Default values assigned from `CLI::App` at main */
+  std::unordered_map<std::string, bool> flags;
+  std::unordered_map<Str, Str> options;
 
   std::mt19937 rng = std::mt19937(std::random_device()());
 

--- a/src/zhaba/zhaba.cpp
+++ b/src/zhaba/zhaba.cpp
@@ -19,9 +19,6 @@ int main(int argc, char **argv) {
 
   app.add_option("file", file_path, "input file to compile")->required();
 
-  zhdata.flags = std::unordered_map<std::string, bool>();
-  zhdata.options = std::unordered_map<Str, Str>();
-  
   app.add_flag(
       "--B,-b", zhdata.flags["B"],
       "sets build target to bytecode, doesn't depend on external compiler");

--- a/src/zhaba/zhaba.cpp
+++ b/src/zhaba/zhaba.cpp
@@ -19,6 +19,9 @@ int main(int argc, char **argv) {
 
   app.add_option("file", file_path, "input file to compile")->required();
 
+  zhdata.flags = std::unordered_map<std::string, bool>();
+  zhdata.options = std::unordered_map<Str, Str>();
+  
   app.add_flag(
       "--B,-b", zhdata.flags["B"],
       "sets build target to bytecode, doesn't depend on external compiler");

--- a/std/str.zh
+++ b/std/str.zh
@@ -148,3 +148,23 @@ fn Str reverse StrR a
     r.push_back(a[i - 1])
 
   <<< r
+
+fn int find StrR a StrR b
+  @ i 0..a.size
+    j := 0
+
+    ? a[i] == b[j]:
+      temp := i
+
+      @ a[i] == b[j]
+        i += 1
+        j += 1
+      
+      ? j == b.size: <<< temp
+      \ i = temp
+        temp = 0
+
+  <<< -1
+
+fn bool contains StrR a StrR b
+  <<< find(a, b) != -1


### PR DESCRIPTION
gcc version 12.1.0 (GCC)
error: SIGFPE (Arithmetic exception)
stack:
```cpp
std::__detail::_Mod_range_hashing::operator() hashtable_policy.h:486
std::__detail::_Hash_code_base::_M_bucket_index hashtable_policy.h:1303
std::_Hashtable::_M_bucket_index hashtable.h:796
std::__detail::_Map_base::operator[] hashtable_policy.h:799
std::unordered_map::operator[] unordered_map.h:984
main zhaba.cpp:14
```