### PR TITLE
Fix std path

### DIFF
--- a/src/parser/syntax_tree_parser.cpp
+++ b/src/parser/syntax_tree_parser.cpp
@@ -678,7 +678,7 @@ ZHModule* parseZh(Path file_path) {
         if (!Path(path).has_extension()) path += ".zh";
 
         if (Path(path).is_relative())
-          path = (file_path.parent_path() / path).string();
+          path.insert(0, zhdata.std_path);
 
         path = resolvePath(path).string();
 


### PR DESCRIPTION
```cpp
Path file_path = "/home/../test.zh";
zhdata.std_path = "/home/../../zhaba-script/std/";
```
If I include ```use std```, it trying to find this file in the same directory (with the file input file) and not in the directory with std
"/home/../std.zh"